### PR TITLE
Revert angular-highcharts version to 6.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2279,9 +2279,9 @@
             }
         },
         "angular-highcharts": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/angular-highcharts/-/angular-highcharts-6.2.0.tgz",
-            "integrity": "sha512-/3kEpMSnUN8mWNrvZ9kYuwkcXmAvdhXUCe+e7cig4H7cIxjw2P7YdHiib2Km70vS1SCNRrihodNzS6si8dmWMw=="
+            "version": "6.1.5",
+            "resolved": "https://registry.npmjs.org/angular-highcharts/-/angular-highcharts-6.1.5.tgz",
+            "integrity": "sha512-MQkHW7urQnb8JG3Ew8eKsozpVYIZEMk8FK+/vFOAfc3M0+kli4DHfr6/uFLzP6a5SA37G4Wuoiwdh/t7pU0rSQ=="
         },
         "angular2-flash-messages": {
             "version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ajv": "^6.5.1",
     "angular-autofocus-fix": "^0.1.0",
     "angular-confirmation-popover": "^4.1.1",
-    "angular-highcharts": "^6.2.0",
+    "angular-highcharts": "^6.1.5",
     "angular2-flash-messages": "^2.0.5",
     "array-includes": "^3.0.3",
     "bootstrap": "^4.1.1",


### PR DESCRIPTION
As 6.2.0 has bug, which throws an error:
Refs cebor/angular-highcharts#193