### PR TITLE
Disable highcharts credits in all graphs

### DIFF
--- a/src/app/accounts/accounts.component.ts
+++ b/src/app/accounts/accounts.component.ts
@@ -48,6 +48,9 @@ export class AccountsComponent extends AccountsComponentCommon implements OnInit
             chart: {
               type: 'line'
             },
+            credits: {
+              enabled: false
+            },
             plotOptions: {
               series: {
                 connectNulls: true,

--- a/src/app/periods/period/period.component.ts
+++ b/src/app/periods/period/period.component.ts
@@ -41,6 +41,9 @@ export class PeriodComponent implements OnInit {
             chart: {
               type: 'line'
             },
+            credits: {
+              enabled: false
+            },
             title: {
               text: 'Period balance over time'
             },

--- a/src/app/transactions/transactions.component.ts
+++ b/src/app/transactions/transactions.component.ts
@@ -145,6 +145,9 @@ export class TransactionsComponent extends Index implements OnInit, OnDestroy {
         chart: {
           type: 'line'
         },
+        credits: {
+          enabled: false
+        },
         title: {
           text: 'Expenses per day'
         },
@@ -195,6 +198,9 @@ export class TransactionsComponent extends Index implements OnInit, OnDestroy {
           chart: {
             type: 'line'
           },
+          credits: {
+            enabled: false
+          },
           plotOptions: {
             series: {
               connectNulls: true,
@@ -212,6 +218,9 @@ export class TransactionsComponent extends Index implements OnInit, OnDestroy {
         this.balancesChart = new Chart({
           chart: {
             type: 'line'
+          },
+          credits: {
+            enabled: false
           },
           plotOptions: {
             series: {


### PR DESCRIPTION
As they are annoying, especially on mobile, when it happens
sometimes, that you accidentally click on it.